### PR TITLE
Fix counting, report against all makers

### DIFF
--- a/src/tasks/report_onboards.js
+++ b/src/tasks/report_onboards.js
@@ -1,54 +1,39 @@
-
-const prompts = require('prompts')
-
-;(async () => {
+(async () => {
   const { Maker, Hotspot } = require('../models')
   const { Op } = require('sequelize')
   const makers = await Maker.findAll()
 
-  const response = await prompts({
-    type: 'select',
-    name: 'makerId',
-    message: 'Select a Maker to generate report for:',
-    choices: makers.map(maker => ({
-      title: maker.name,
-      value: maker.id,
-    })),
-  });
+  const results = await Promise.all(makers.map(async (maker) => {
+    const total_count = await Hotspot.count({
+      where: {
+        [Op.and]:
+          [
+            { makerId: maker.id },
+            { onboardingKey: {[Op.ne]: null} },
+          ]
+      }
+    })
 
-  if (!response.makerId) {
-    return process.exit(0)
-  }
+    const unonboarded_count = await Hotspot.count({
+      where: {
+        [Op.and]:
+          [
+            { makerId: maker.id },
+            { publicAddress: {[Op.eq]: null} },
+            { onboardingKey: {[Op.ne]: null} },
+          ]
+      }
+    })
 
-  const maker = await Maker.findByPk(response.makerId)
-
-  const total_count = await Hotspot.count({
-    where: {
-      [Op.and]:
-        [
-          { makerId: maker.id },
-          { onboardingKey: {[Op.ne]: null} },
-        ]
+    return {
+      maker: maker.name,
+      makerId: maker.id,
+      totalCount: total_count,
+      unonboardedCount: unonboarded_count,
     }
-  })
+  }))
 
-  const unonboarded_count = await Hotspot.count({
-    where: {
-      [Op.and]:
-        [
-          { makerId: maker.id },
-          { publicAddress: {[Op.eq]: null} },
-          { onboardingKey: {[Op.ne]: null} },
-        ]
-    }
-  })
-
-  console.log({
-    maker: maker.name,
-    makerId: maker.id,
-    totalCount: total_count,
-    unonboardedCount: unonboarded_count,
-  })
+  console.log(results)
 
   return process.exit(0)
 })()

--- a/src/tasks/report_onboards.js
+++ b/src/tasks/report_onboards.js
@@ -23,20 +23,24 @@ const prompts = require('prompts')
   const maker = await Maker.findByPk(response.makerId)
 
   const total_count = await Hotspot.count({
-    [Op.and]:
+    where: {
+      [Op.and]:
         [
-            { makerId: maker.id },
-            { onboardingKey: {[Op.ne]: null} },
+          { makerId: maker.id },
+          { onboardingKey: {[Op.ne]: null} },
         ]
+    }
   })
 
   const unonboarded_count = await Hotspot.count({
-    [Op.and]:
+    where: {
+      [Op.and]:
         [
-            { makerId: maker.id },
-            { publicAddress: {[Op.eq]: null} },
-            { onboardingKey: {[Op.ne]: null} },
+          { makerId: maker.id },
+          { publicAddress: {[Op.eq]: null} },
+          { onboardingKey: {[Op.ne]: null} },
         ]
+    }
   })
 
   console.log({


### PR DESCRIPTION
Call `count()` with the right keywords so that it recognizes that actual predicate I'd like it to use
when perfomring a count of Hotspots with certain properties.